### PR TITLE
fix: clicking on menu button makes the page jump to top position

### DIFF
--- a/lib/themes/egg/layout/partial/aside.nunjucks
+++ b/lib/themes/egg/layout/partial/aside.nunjucks
@@ -8,6 +8,7 @@
 var mobileTrigger = document.getElementById('mobileTrigger');
 var mobileAside = document.getElementById('mobileAside');
 mobileTrigger.onclick = function(e) {
+  e.preventDefault();
   if (mobileAside.className.indexOf('mobile-show') === -1) {
     mobileAside.className += ' mobile-show';
   } else {


### PR DESCRIPTION
Steps to reproduce:
- open official website: https://eggjs.org/.
- reduce browser width to smaller, ensure menu button appears at top right of page.
- scroll page down a bit.
- click on menu button.

Result: page jump to top.
Expected behavior: page position shouldn't change.