### PR TITLE
feat: 自动切换语言。

### DIFF
--- a/lib/themes/egg/layout/partial/aside.nunjucks
+++ b/lib/themes/egg/layout/partial/aside.nunjucks
@@ -47,10 +47,10 @@ mobileAside.onclick = function(e) {
   const targetId = e.target.id;
   if (targetId && (targetId.indexOf('title-') > -1 || targetId.indexOf('collapse-icon-') > -1)) {
     const title = targetId.replace('title-', '').replace('collapse-icon-', '');
-    try { 
-      // the the browser may have no localStroage or JSON.parse may throw exception.
+    try {
+      // the browser may have no localStorage or JSON.parse may throw exception.
       const menuInfo = JSON.parse(window.localStorage.getItem('menuInfo'));
-        
+
       // current menu status
       const curClosed = menuInfo[title] ? menuInfo[title].closed : false; // default false
 
@@ -76,8 +76,8 @@ mobileTrigger.onclick = function(e) {
 (function() {
   // save data to localStorage because the page will refresh when user change the url.
   let menuInfo;
-  try { 
-    // the the browser may have no localStroage or JSON.parse may throw exception.
+  try {
+    // the browser may have no localStorage or JSON.parse may throw exception.
     menuInfo = JSON.parse(window.localStorage.getItem('menuInfo'));
     if (!menuInfo) {
       menuInfo = {};

--- a/lib/themes/egg/scripts/helpers.js
+++ b/lib/themes/egg/scripts/helpers.js
@@ -72,13 +72,26 @@ hexo.extend.helper.register('language_list', function() {
     language.forEach(item => {
       if (lanRef[item]) {
         const highlight = this.page.lang === item ? 'style="color: #22ab28"' : '';
-        languageList += `<li><a id="${item}" href="/${item}/${this.page.canonical_path}" ${highlight}>${lanRef[item]}</a></li>`;
+        languageList += `<li><a onclick="rememberLang('${item}')" id="${item}" href="/${item}/${this.page.canonical_path}" ${highlight}>${lanRef[item]}</a></li>`;
       }
     });
     languageList += '</ul>';
   }
 
-  return languageList;
+  return languageList + `<script
+type="text/javascript">
+    function rememberLang(lang){
+      localStorage.setItem('lang', lang)
+    }
+
+    var l = localStorage.getItem('lang') || navigator.language.toLowerCase();
+    var clientLanRef = ${JSON.stringify(lanRef)};
+    var pageLang = ${JSON.stringify(this.page.lang)}; 
+    
+    if(location.pathname === '/' && !!clientLanRef[l] && l !== pageLang) {
+      location.href='/' + l + '/'
+    }
+</script>`;
 });
 
 hexo.extend.helper.register('deer_stat', function () {


### PR DESCRIPTION
**问题**：
目前 egg 文档总是默认显示英文，作为一个中文用户，每次打开都需要多做一次额外的切换语言动作。

**解决方案**：
可以给在线文档添加一个自动判断用户语言的功能。

**分析**：
- 看了一下代码，似乎需要由 hexo 来完成这件事情（在 page.lang 初始化时读取客户端语言设置）。但是 hexo 似乎在 egg 框架之外，不好控制。
- 而且 eggjs 的文档 host 在 github 的 gh-pages 上，为静态页面，可能服务端做的会不生效。

**退而求其次**：
仅在 / 路径下用客户端 js 来判断，如果当前页面渲染所使用的语言与用户的设置不一致，就做一个跳转。一旦用户点击过语言切换，就记录在 localStorage 里，下次还会使用他上次切换到的语言。

**测试**：
在本地 eggjs 项目下 通过 npm run doc-server 尝试，效果达到预期。跳转得很快，用户几乎无感知。