### PR TITLE
Feat: Add the support for Win

### DIFF
--- a/lib/jsdoc.js
+++ b/lib/jsdoc.js
@@ -13,8 +13,15 @@ const PATH = process.env.PATH;
 const tmp = path.join(os.tmpdir(), 'jsdoc');
 
 module.exports = function* ({ baseDir, target }) {
+
   const config = yield getConfig({ baseDir });
-  yield runscript(`jsdoc -c ${config} -d ${target} -r`, {
+
+  let exeCmd = `jsdoc -c ${config} -d ${target} -r`;
+  if (process.platform === 'win32') {
+    exeCmd = path.join(process.cwd(), 'node_modules', '.bin', 'jsdoc');
+    exeCmd += ` -c ${config} -d ${target} -r`;
+  }
+  yield runscript(exeCmd, {
     env: {
       PATH: `${path.join(__dirname, '../node_modules/.bin')}:${PATH}`,
     },


### PR DESCRIPTION
We cannot directly call 'jsdoc' as the command in any windows platform, so this is the feat for it.

Ref: https://github.com/eggjs/egg/pull/3654